### PR TITLE
feat(worker): Node worker_threads helper + CLI docs

### DIFF
--- a/docs/CLI_USAGE.md
+++ b/docs/CLI_USAGE.md
@@ -1,0 +1,91 @@
+# CLI / Node Usage
+
+StreamMDX is designed for browser + React, but the worker-first architecture makes it easy to reuse the same parsing and patch stream in non-browser runtimes (e.g. Ink-based TUIs).
+
+This doc covers:
+
+- Running the StreamMDX worker in **Node** via `worker_threads`
+- Consuming `PATCH` messages to maintain a `DocumentSnapshot`
+- Rendering snapshots with a terminal renderer (Ink, etc.)
+
+## 1) Run the worker in Node (recommended helper)
+
+Use the Node helper, which spawns a `worker_threads` worker and installs WebWorker-compatible shims (`self`, `postMessage`, `onmessage`) so the **hosted browser bundle** can run under Node.
+
+```ts
+import { createWorkerThread } from "stream-mdx/worker/node";
+import { applyPatchBatch, createInitialSnapshot, type WorkerOut } from "stream-mdx/core";
+
+const worker = createWorkerThread({ stdout: true, stderr: true });
+let snapshot = createInitialSnapshot();
+
+worker.on("message", (msg: WorkerOut) => {
+  if (msg.type === "PATCH") {
+    snapshot.blocks = applyPatchBatch(snapshot, msg.patches);
+  }
+});
+
+worker.postMessage({
+  type: "INIT",
+  initialContent: "",
+  prewarmLangs: ["typescript"],
+  docPlugins: { tables: true, html: true, mdx: true, math: true, footnotes: true },
+  mdx: { compileMode: "worker" },
+});
+
+worker.postMessage({ type: "APPEND", text: "## Hello\\n\\nStreaming **markdown**" });
+worker.postMessage({ type: "FINALIZE" });
+```
+
+Notes:
+
+- `snapshot.blocks` is an ordered `Block[]` representation suitable for rendering in a TUI.
+- If you want to render the full node tree (not just blocks), inspect `snapshot.nodes` from `createInitialSnapshot()` / `applyPatchBatch()`.
+
+## 2) Hosted worker bundle location (for advanced setups)
+
+The self-contained hosted worker bundle is shipped in this package:
+
+- `node_modules/@stream-mdx/worker/dist/hosted/markdown-worker.js`
+
+If you are using Node 20+, you can resolve it via package exports:
+
+```ts
+const url = import.meta.resolve("@stream-mdx/worker/hosted/markdown-worker.js");
+```
+
+Most consumers should prefer `createWorkerThread()` so you don’t have to write the shims yourself.
+
+## 3) Feeding Ink (or other TUI renderers)
+
+At a high level:
+
+1. Create and own a `DocumentSnapshot` (`createInitialSnapshot()`).
+2. Apply each `PATCH` batch (`applyPatchBatch()`).
+3. Render `snapshot.blocks` into your terminal UI.
+
+For streaming, treat the markdown input as append-only and send `APPEND` messages as chunks arrive.
+
+## 4) Message protocol (overview)
+
+Messages sent **to** the worker (`WorkerIn`) include:
+
+- `INIT` (initial content, plugin toggles, MDX compile mode)
+- `APPEND` (append-only streaming text)
+- `FINALIZE` (finalize blocks once the stream ends)
+- `SET_CREDITS` (optional backpressure control)
+
+Messages received **from** the worker (`WorkerOut`) include:
+
+- `PATCH` (apply these patches to your snapshot)
+- `METRICS` (optional performance telemetry)
+- `ERROR` (worker-side errors; treat as fatal or surface to logs)
+
+## 5) Shiki diff highlighting (roadmap note)
+
+StreamMDX currently uses Shiki inside the worker to produce **HTML** syntax highlighting for markdown code blocks.
+
+For CLI UIs that need ANSI-colored diffs:
+
+- **Today**: use Shiki directly (e.g. highlight unified diffs as language `"diff"`), or implement a small adapter that converts Shiki tokens to ANSI in your TUI.
+- **Potential future addition**: a dedicated helper (likely a separate package) that produces Shiki-tokenized diff segments and/or ANSI output without pulling React into CLI builds.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -15,6 +15,14 @@ mkdir -p public/workers
 cp node_modules/@stream-mdx/worker/dist/hosted/markdown-worker.js public/workers/markdown-worker.js
 ```
 
+## Render Markdown (CLI / Node)
+
+If you want to reuse the worker + patch stream in a terminal UI (Ink, etc.), use the Node worker helper:
+
+- `stream-mdx/worker/node` (or `@stream-mdx/worker/node`)
+
+See `docs/CLI_USAGE.md` for a complete example that consumes `PATCH` messages into a `DocumentSnapshot`.
+
 ## Render Markdown (React)
 
 ### Next.js (App Router)
@@ -46,4 +54,3 @@ export default function App() {
 - Props/types: `docs/PUBLIC_API.md`
 - MDX + customization: `docs/REACT_INTEGRATION_GUIDE.md`
 - Plugin/worker cookbook: `docs/STREAMING_MARKDOWN_PLUGINS_COOKBOOK.md`
-

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -10,13 +10,14 @@ StreamMDX is published as both scoped packages and an unscoped convenience wrapp
 | --- | --- |
 | `stream-mdx` | You want a single dependency and stable import paths (recommended for apps). |
 | `@stream-mdx/react` | You want the React surface without the wrapper. |
-| `@stream-mdx/worker` | You want the worker client + hosted worker bundle. |
+| `@stream-mdx/worker` | You want the worker client + hosted worker bundle (browser + Node). |
 | `@stream-mdx/core` | You want types + perf/sanitization helpers (no React). |
 | `@stream-mdx/plugins/*` | You are building/customizing a worker bundle or need plugin primitives. |
 
 When you install `stream-mdx`, you can also import:
 
 - `stream-mdx/react`, `stream-mdx/worker`, `stream-mdx/core`
+- `stream-mdx/worker/node` (Node `worker_threads` helper)
 - `stream-mdx/plugins/*` (common plugin entrypoints; useful for pnpm users)
 
 ---
@@ -107,6 +108,15 @@ Worker ownership semantics:
 
 For advanced worker instantiation (CSP overrides, shared worker instances), see `createDefaultWorker()` in `stream-mdx/worker`.
 
+### Node / CLI runtimes
+
+To run the hosted worker bundle in Node (via `worker_threads`), use:
+
+- `@stream-mdx/worker/node` (scoped)
+- `stream-mdx/worker/node` (convenience wrapper)
+
+See `docs/CLI_USAGE.md` for an example that consumes `PATCH` messages into a `DocumentSnapshot`.
+
 ---
 
 ## 3) Features
@@ -186,4 +196,3 @@ If you need deeper control (custom tokenizers, custom streaming matchers, custom
 - `docs/STREAMING_MARKDOWN_PLUGINS_COOKBOOK.md`
 - `stream-mdx/plugins/*` (convenience package)
 - `@stream-mdx/plugins/*` (scoped packages)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Start here (in order):
 ## Topics
 
 - **Getting started**: `docs/GETTING_STARTED.md`
+- **CLI / Node usage**: `docs/CLI_USAGE.md`
 - **Configuration**: `docs/CONFIGURATION.md`
 - **Plugins & worker customization**: `docs/STREAMING_MARKDOWN_PLUGINS_COOKBOOK.md`
 - **Security model (HTML/CSP)**: `docs/SECURITY_MODEL.md`

--- a/packages/markdown-v2-worker/README.md
+++ b/packages/markdown-v2-worker/README.md
@@ -25,6 +25,16 @@ Then point StreamMDX at it:
 <StreamingMarkdown worker="/workers/markdown-worker.js" />
 ```
 
+## Node / CLI worker threads
+
+To run the hosted worker bundle in Node (e.g., Ink TUIs), use:
+
+```ts
+import { createWorkerThread } from "@stream-mdx/worker/node";
+```
+
+This spawns a `worker_threads` worker and installs WebWorker-like shims so the hosted bundle can run under Node.
+
 ## MDX compilation parity helper
 
 If you compile MDX on the server (e.g. Next.js API route), use the same compilation logic as the worker:

--- a/packages/markdown-v2-worker/package.json
+++ b/packages/markdown-v2-worker/package.json
@@ -35,7 +35,14 @@
       "types": "./dist/streaming/custom-matcher.d.ts",
       "import": "./dist/streaming/custom-matcher.mjs",
       "require": "./dist/streaming/custom-matcher.cjs"
-    }
+    },
+    "./node": {
+      "types": "./dist/node/index.d.ts",
+      "import": "./dist/node/index.mjs",
+      "require": "./dist/node/index.cjs"
+    },
+    "./hosted/markdown-worker.js": "./dist/hosted/markdown-worker.js",
+    "./dist/hosted/markdown-worker.js": "./dist/hosted/markdown-worker.js"
   },
   "files": [
     "dist",

--- a/packages/markdown-v2-worker/src/node/index.ts
+++ b/packages/markdown-v2-worker/src/node/index.ts
@@ -1,0 +1,62 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { Worker, type WorkerOptions } from "node:worker_threads";
+
+export interface CreateWorkerThreadOptions extends Omit<WorkerOptions, "type" | "workerData"> {
+  /**
+   * Override the worker bundle module that should be executed inside the thread.
+   *
+   * Defaults to the hosted worker shipped with `@stream-mdx/worker` at
+   * `dist/hosted/markdown-worker.js`.
+   */
+  workerBundle?: string | URL;
+  /**
+   * Extra data passed to the thread. This will be merged with the internal
+   * `bundleUrl` field used by the bootstrap.
+   */
+  workerData?: Record<string, unknown>;
+}
+
+/**
+ * Returns the file URL for the hosted worker bundle shipped with `@stream-mdx/worker`.
+ */
+export function getHostedWorkerBundleUrl(): URL {
+  return new URL("../hosted/markdown-worker.js", getModuleUrl());
+}
+
+/**
+ * Creates a Node `worker_threads` Worker running the StreamMDX hosted worker bundle.
+ *
+ * The thread bootstrap installs WebWorker-like shims (`self`, `postMessage`, `onmessage`)
+ * so the same hosted bundle used in browsers can run under Node.
+ */
+export function createWorkerThread(options: CreateWorkerThreadOptions = {}): Worker {
+  const { workerBundle, workerData, ...workerOptions } = options;
+  const runnerUrl = new URL("./worker-thread-entry.mjs", getModuleUrl());
+  const bundleUrl = normalizeWorkerBundleUrl(workerBundle) ?? getHostedWorkerBundleUrl();
+
+  return new Worker(runnerUrl, {
+    ...workerOptions,
+    workerData: {
+      ...(workerData ?? {}),
+      bundleUrl: bundleUrl.href,
+    },
+  });
+}
+
+function normalizeWorkerBundleUrl(value: string | URL | undefined): URL | undefined {
+  if (!value) return undefined;
+  if (value instanceof URL) return value;
+  try {
+    return new URL(value);
+  } catch {
+    return pathToFileURL(path.resolve(value));
+  }
+}
+
+function getModuleUrl(): string {
+  if (typeof __filename === "string" && __filename.length > 0) {
+    return pathToFileURL(__filename).href;
+  }
+  return import.meta.url;
+}

--- a/packages/markdown-v2-worker/src/node/worker-thread-entry.ts
+++ b/packages/markdown-v2-worker/src/node/worker-thread-entry.ts
@@ -1,0 +1,95 @@
+import { pathToFileURL } from "node:url";
+import { parentPort, workerData } from "node:worker_threads";
+
+type BootstrapData = {
+  bundleUrl?: string;
+};
+
+const port = parentPort;
+if (!port) {
+  throw new Error("[stream-mdx] worker thread bootstrap missing parentPort.");
+}
+
+const globalAny = globalThis as unknown as {
+  self?: unknown;
+  postMessage?: (value: unknown) => void;
+  onmessage?: ((event: { data: unknown }) => void | Promise<void>) | null;
+  addEventListener?: (type: string, listener: (event: { data: unknown }) => void) => void;
+  removeEventListener?: (type: string, listener: (event: { data: unknown }) => void) => void;
+};
+
+if (!globalAny.self) {
+  globalAny.self = globalThis;
+}
+
+globalAny.postMessage = (value: unknown) => {
+  port.postMessage(value);
+};
+
+const messageListeners = new Set<(event: { data: unknown }) => void>();
+globalAny.addEventListener = (type: string, listener: (event: { data: unknown }) => void) => {
+  if (type !== "message") return;
+  messageListeners.add(listener);
+};
+globalAny.removeEventListener = (type: string, listener: (event: { data: unknown }) => void) => {
+  if (type !== "message") return;
+  messageListeners.delete(listener);
+};
+
+let ready = false;
+const buffered: unknown[] = [];
+
+function dispatchMessage(data: unknown): void {
+  const event = { data };
+
+  const handler = globalAny.onmessage;
+  if (typeof handler === "function") {
+    try {
+      handler(event);
+    } catch (error) {
+      console.error("[stream-mdx] worker thread onmessage threw:", error);
+    }
+  }
+
+  if (messageListeners.size > 0) {
+    for (const listener of messageListeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        console.error("[stream-mdx] worker thread message listener threw:", error);
+      }
+    }
+  }
+}
+
+port.on("message", (data: unknown) => {
+  if (!ready) {
+    buffered.push(data);
+    return;
+  }
+  dispatchMessage(data);
+});
+
+const bootstrap = (workerData ?? {}) as BootstrapData;
+const bundleUrl =
+  typeof bootstrap.bundleUrl === "string" && bootstrap.bundleUrl.length > 0 ? bootstrap.bundleUrl : new URL("../hosted/markdown-worker.js", getModuleUrl()).href;
+
+void (async () => {
+  await import(bundleUrl);
+  ready = true;
+  if (buffered.length > 0) {
+    for (const data of buffered.splice(0, buffered.length)) {
+      dispatchMessage(data);
+    }
+  }
+})().catch((error) => {
+  console.error("[stream-mdx] Failed to load hosted worker bundle in worker thread:", error);
+  throw error;
+});
+
+function getModuleUrl(): string {
+  if (typeof __filename === "string" && __filename.length > 0) {
+    return pathToFileURL(__filename).href;
+  }
+  return import.meta.url;
+}

--- a/packages/markdown-v2-worker/tsup.config.ts
+++ b/packages/markdown-v2-worker/tsup.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
     resolve("src/worker-client.ts"),
     resolve("src/mdx-compile.ts"),
     resolve("src/streaming/custom-matcher.ts"),
+    resolve("src/node/index.ts"),
+    resolve("src/node/worker-thread-entry.ts"),
   ],
   dts: true,
   splitting: false,

--- a/packages/stream-mdx/package.json
+++ b/packages/stream-mdx/package.json
@@ -41,6 +41,11 @@
       "import": "./dist/worker/mdx-compile.mjs",
       "require": "./dist/worker/mdx-compile.cjs"
     },
+    "./worker/node": {
+      "types": "./dist/worker/node.d.ts",
+      "import": "./dist/worker/node.mjs",
+      "require": "./dist/worker/node.cjs"
+    },
     "./plugins": {
       "types": "./dist/plugins.d.ts",
       "import": "./dist/plugins.mjs",

--- a/packages/stream-mdx/src/worker/node.ts
+++ b/packages/stream-mdx/src/worker/node.ts
@@ -1,0 +1,2 @@
+export * from "@stream-mdx/worker/node";
+

--- a/packages/stream-mdx/tsup.config.ts
+++ b/packages/stream-mdx/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "src/react.ts",
     "src/worker.ts",
     "src/worker/mdx-compile.ts",
+    "src/worker/node.ts",
     "src/plugins.ts",
     "src/plugins/base.ts",
     "src/plugins/callouts.ts",


### PR DESCRIPTION
- Adds `@stream-mdx/worker/node` + `stream-mdx/worker/node` (`createWorkerThread`, `getHostedWorkerBundleUrl`) for running the hosted worker bundle under Node via `worker_threads`.
- Exposes the hosted worker bundle via package exports (`@stream-mdx/worker/hosted/markdown-worker.js`).
- Adds CLI/Ink integration docs (`docs/CLI_USAGE.md`) and links from Getting Started/Public API.

CI: run on PR.